### PR TITLE
always use startService

### DIFF
--- a/android/src/main/java/app/notifee/core/ForegroundService.java
+++ b/android/src/main/java/app/notifee/core/ForegroundService.java
@@ -46,12 +46,8 @@ public class ForegroundService extends Service {
     intent.putExtra("notification", notification);
     intent.putExtra("notificationBundle", notificationBundle);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      ContextHolder.getApplicationContext().startForegroundService(intent);
-    } else {
-      // TODO test this on older device
-      ContextHolder.getApplicationContext().startService(intent);
-    }
+    // TODO test this on older device
+    ContextHolder.getApplicationContext().startService(intent);
   }
 
   static void stop() {


### PR DESCRIPTION
We don't have a use for startForegroundService as we will always be starting the service while the app is foregrounded. [This](https://github.com/invertase/notifee/issues/127#issuecomment-1340641061) comment indicates since we are always starting the service from the foreground we can just use `startService`.